### PR TITLE
Added `inIndex` method to SearchBuilder

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -161,6 +161,13 @@ To get the raw DSL query that will be executed you can call `toDSL()`:
 $dsl = Book::search()->match('title','pulp')->toDSL();
 ```
 
+#### Change index
+
+To switch to a different index for a single query, simply use the `inIndex` method.
+
+$result = Book::search()->inIndex('special-books')->match('title','pulp')->get();
+
+
 #### Pagination
 
 ```php
@@ -292,7 +299,7 @@ php artisan mapping:run
 
 #### Updating Mappings
 
-If your update consists only of adding a new field mapping you can always update our model map with your new field and run: 
+If your update consists only of adding a new field mapping you can always update our model map with your new field and run:
 
 ```bash
 php artisan mapping:rerun

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -101,6 +101,18 @@ class Connection
     }
 
     /**
+     * Set the currently used index.
+     *
+     * @return Connection
+     */
+    public function setIndex($index)
+    {
+        $this->index = $index;
+
+        return $this;
+    }
+
+    /**
      * Execute a map statement on index;.
      *
      * @param array $mappings

--- a/src/DSL/SearchBuilder.php
+++ b/src/DSL/SearchBuilder.php
@@ -689,6 +689,18 @@ class SearchBuilder
     }
 
     /**
+     * Overwrite the default index setting for this query.
+     *
+     * @return SearchBuilder
+     */
+    public function inIndex($index)
+    {
+        $this->connection->setIndex($index);
+
+        return $this;
+    }
+
+    /**
      * Execute the search query against elastic and return the raw result if the model is not set.
      *
      * @return PlasticResult

--- a/tests/DSL/SearchBuilderTest.php
+++ b/tests/DSL/SearchBuilderTest.php
@@ -416,6 +416,24 @@ class SearchBuilderTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function it_overwrites_the_connections_default_index()
+    {
+        $builder = $this->getBuilder();
+        $connection = $builder->getConnection();
+
+        $connection->shouldReceive('setIndex')
+                   ->with('test')
+                   ->set('index', 'test')
+                   ->once();
+
+        $builder->inIndex('test');
+
+        $this->assertEquals('test', $connection->index);
+    }
+
+    /**
+     * @test
+     */
     public function it_executes_the_query_and_returns_the_raw_result()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
This PR enables the user to optionally query a different index than is specified as default in the config file.