### PR TITLE
Fix missing index argument in blueprint resolver closure call

### DIFF
--- a/src/Map/Builder.php
+++ b/src/Map/Builder.php
@@ -88,7 +88,7 @@ class Builder
     protected function createBlueprint($type, Closure $callback = null, $index = null)
     {
         if (isset($this->resolver)) {
-            return call_user_func($this->resolver, $type, $callback);
+            return call_user_func($this->resolver, $type, $callback, $index);
         }
 
         return new Blueprint($type, $callback, $index);


### PR DESCRIPTION
The arguments being passed to the default `Blueprint()` class is does not match the closure that provides for a custom resolving of Blueprint(), index the last argument is missing.