### PR TITLE
Add ElasticSearch 5.x text and keyword field support replacing string field datatype

### DIFF
--- a/src/Map/Blueprint.php
+++ b/src/Map/Blueprint.php
@@ -101,6 +101,32 @@ class Blueprint
     }
 
     /**
+     * Add a text field to the map. Previously analyzed string.
+     *
+     * @param string $field
+     * @param array  $attributes
+     *
+     * @return Fluent
+     */
+    public function text($field, $attributes = [])
+    {
+        return $this->addField('text', $field, $attributes);
+    }
+
+    /**
+     * Add a keyword field to the map. Previously not-analyzed exact string.
+     *
+     * @param string $field
+     * @param array  $attributes
+     *
+     * @return Fluent
+     */
+    public function keyword($field, $attributes = [])
+    {
+        return $this->addField('keyword', $field, $attributes);
+    }
+
+    /**
      * Add a date field to the map.
      *
      * @param string $field

--- a/src/Map/Grammar.php
+++ b/src/Map/Grammar.php
@@ -304,6 +304,68 @@ class Grammar
     }
 
     /**
+     * Compile a text map.
+     *
+     * @param Fluent $fluent
+     *
+     * @return array
+     */
+    public function compileText(Fluent $fluent)
+    {
+        $map = [
+            'type'                       => 'text',
+            'analyzer'                   => $fluent->analyzer,
+            'boost'                      => $fluent->boost,
+            'eager_global_ordinals'      => $fluent->eager_global_ordinals,
+            'fielddata'                  => $fluent->fielddata,
+            'fielddata_frequency_filter' => $fluent->fielddata_frequency_filter,
+            'fields'                     => $fluent->fields,
+            'include_in_all'             => $fluent->include_in_all,
+            'index'                      => $fluent->index,
+            'index_options'              => $fluent->index_options,
+            'norms'                      => $fluent->norms,
+            'position_increment_gap'     => $fluent->position_increment_gap,
+            'search_analyzer'            => $fluent->search_analyzer,
+            'search_quote_analyzer'      => $fluent->search_quote_analyzer,
+            'similarity'                 => $fluent->similarity,
+            'store'                      => $fluent->store,
+            'term_vector'                => $fluent->term_vector,
+        ];
+
+        return $this->formatMap($map);
+    }
+
+    /**
+     * Compile a keyword map.
+     *
+     * @param Fluent $fluent
+     *
+     * @return array
+     */
+    public function compileKeyword(Fluent $fluent)
+    {
+        $map = [
+            'type'                  => 'keyword',
+            'boost'                 => $fluent->boost,
+            'doc_values'            => $fluent->doc_values,
+            'eager_global_ordinals' => $fluent->eager_global_ordinals,
+            'fields'                => $fluent->fields,
+            'ignore_above'          => $fluent->ignore_above,
+            'include_in_all'        => $fluent->include_in_all,
+            'index'                 => $fluent->index,
+            'index_options'         => $fluent->index_options,
+            'normalizer'            => $fluent->normalizer,
+            'norms'                 => $fluent->norms,
+            'null_value'            => $fluent->null_value,
+            'search_analyzer'       => $fluent->search_analyzer,
+            'similarity'            => $fluent->similarity,
+            'store'                 => $fluent->store,
+        ];
+
+        return $this->formatMap($map);
+    }
+
+    /**
      * Compile a numeric map.
      *
      * @param Fluent $fluent

--- a/tests/Map/MapGrammarTest.php
+++ b/tests/Map/MapGrammarTest.php
@@ -187,6 +187,30 @@ class MapGrammarTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function it_adds_a_text_map()
+    {
+        $blueprint = new Blueprint('post');
+        $blueprint->create();
+        $blueprint->text('body', ['analyzer' => 'foo', 'boost' => true]);
+        $statement = $blueprint->toDSL($this->getGrammar());
+        $this->assertEquals(['body' => ['type' => 'text', 'analyzer' => 'foo', 'boost' => true]], $statement);
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_a_keyword_map()
+    {
+        $blueprint = new Blueprint('post');
+        $blueprint->create();
+        $blueprint->keyword('body', ['boost' => true, 'store' => true]);
+        $statement = $blueprint->toDSL($this->getGrammar());
+        $this->assertEquals(['body' => ['type' => 'keyword', 'boost' => true, 'store' => true]], $statement);
+    }
+
+    /**
+     * @test
+     */
     public function it_adds_a_nested_map()
     {
         $blueprint = new Blueprint('post');


### PR DESCRIPTION
In ElasticSearch 5 string field datatype has been split into text and keyword. String is still supported for backward compatible.

> ## Mapping changes: `string` fields replaced by `text/keyword` fields
> 
> The `string` field datatype has been replaced by the `text` field for full text `analyzed` content, and the `keyword` field for `not-analyzed` exact `string` values. For backwards compatibility purposes, during the 5.x series:
> 
> * `string` fields on pre-5.0 indices will function as before.
> * New `string` fields can be added to pre-5.0 indices as before.
> * `text` and `keyword` fields can also be added to pre-5.0 indices.
> * When adding a `string` field to a new index, the field mapping will be rewritten as a `text` or `keyword` field if possible, otherwise an exception will be thrown. Certain configurations that were possible with string fields are no longer possible with `text/keyword` fields such as enabling `term_vectors` on a `not-analyzed` `keyword` field.
>
> -- **Ref:** <cite>[Elasticsearch Reference [5.x] » Breaking changes](https://www.elastic.co/guide/en/elasticsearch/reference/5.x/breaking_50_mapping_changes.html#_literal_string_literal_fields_replaced_by_literal_text_literal_literal_keyword_literal_fields)</cite>
