### PR TITLE
Add supported parameters to nested grammar compile method

### DIFF
--- a/src/Map/Grammar.php
+++ b/src/Map/Grammar.php
@@ -345,10 +345,16 @@ class Grammar
             $callback($blueprint);
         }
 
-        return [
-            'type'       => 'nested',
-            'properties' => $this->compileFields($blueprint->getFields()),
+        $map = [
+            'type'              => 'nested',
+            'dynamic'           => $fluent->dynamic,
+            'include_in_all'    => $fluent->include_in_all,
+            'include_in_root'   => $fluent->include_in_root,
+            'include_in_parent' => $fluent->include_in_parent,
+            'properties'        => $this->compileFields($blueprint->getFields()),
         ];
+
+        return $this->formatMap($map);
     }
 
     /**


### PR DESCRIPTION
The current nested datatype grammar compile does not support adding parameters preventing use of advanced features like 'include_in_parent'.