### PR TITLE
Add auto increment column to mappings table for sqlite support

### DIFF
--- a/src/Mappings/Mappings.php
+++ b/src/Mappings/Mappings.php
@@ -141,6 +141,8 @@ class Mappings
             // The mappings table is responsible for keeping track of which of the
             // mappings have actually run for the application. We'll create the
             // table to hold the mapping file's path as well as the batch ID.
+            $table->increments('id');
+            
             $table->string('mapping');
 
             $table->integer('batch');

--- a/src/Mappings/Mappings.php
+++ b/src/Mappings/Mappings.php
@@ -142,7 +142,7 @@ class Mappings
             // mappings have actually run for the application. We'll create the
             // table to hold the mapping file's path as well as the batch ID.
             $table->increments('id');
-            
+
             $table->string('mapping');
 
             $table->integer('batch');


### PR DESCRIPTION
Without an auto increment column on the mappings table, sqlite will not allow truncating and throw the following error:

[Illuminate\Database\QueryException]                                                                                       
SQLSTATE[HY000]: General error: 1 no such table: sqlite_sequence (SQL: delete from sqlite_sequence where name = mappings)