### PR TITLE
Add Macroable Trait to SearchBuilder

### DIFF
--- a/src/DSL/SearchBuilder.php
+++ b/src/DSL/SearchBuilder.php
@@ -3,6 +3,7 @@
 namespace Sleimanx2\Plastic\DSL;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Traits\Macroable;
 use ONGR\ElasticsearchDSL\Query\FullText\CommonTermsQuery;
 use ONGR\ElasticsearchDSL\Query\FullText\MatchQuery;
 use ONGR\ElasticsearchDSL\Query\FullText\MultiMatchQuery;
@@ -36,6 +37,8 @@ use Sleimanx2\Plastic\Searchable;
 
 class SearchBuilder
 {
+    use Macroable;
+    
     /**
      * An instance of DSL query.
      *

--- a/tests/DSL/SearchBuilderTest.php
+++ b/tests/DSL/SearchBuilderTest.php
@@ -525,6 +525,20 @@ class SearchBuilderTest extends PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(\Sleimanx2\Plastic\PlasticPaginator::class, $builder->paginate());
     }
+    
+    /**
+     * @test
+     */
+    public function it_creates_macros()
+    {
+        $builder = $this->getBuilder();
+
+        $builder->macro('sortByID',function(){
+            $this->sortBy('id', 'desc');
+        });
+
+        $this->assertTrue($builder->hasMacro('sortByID'));
+    }
 
     private function getBuilder()
     {


### PR DESCRIPTION
Hi, I guess is useful to add the Macroable trait to SearchBuilder to DRY some queries like:

```php
SearchBuilder::macro('language', function(){
            return $this->sortBy('_script','desc', [
                'script'=> [
                    'lang'=>'painless',
                    'inline'=> "params.factor.get(doc['language'].value)",
                    'params' => [
                        'factor' => [
                            'es' => 1,
                            'en' => 0
                        ]
                    ]
                ], 'type' => 'number']);
 });
```