### PR TITLE
Replaces __call with static methods

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -160,25 +160,24 @@ trait Searchable
     }
 
     /**
-     * Handle dynamic method calls into the model.
-     *
-     * @param string $method
-     * @param array  $parameters
+     * Start an elastic dsl search query builder
      *
      * @return mixed
      */
-    public function __call($method, $parameters)
+    public static function search()
     {
-        if ($method == 'search') {
-            //Start an elastic dsl search query builder
-            return Plastic::search()->model($this);
-        }
+        //Start an elastic dsl search query builder
+        return Plastic::search()->model((new static));
+    }
 
-        if ($method == 'suggest') {
-            //Start an elastic dsl suggest query builder
-            return Plastic::suggest()->index($this->getDocumentIndex());
-        }
-
-        return parent::__call($method, $parameters);
+    /**
+     * Start an elastic dsl suggest query builder
+     *
+     * @return mixed
+     */
+    public static function suggest()
+    {
+        //Start an elastic dsl suggest query builder
+        return Plastic::suggest()->index((new static)->getDocumentIndex());
     }
 }


### PR DESCRIPTION
Hi,

I don't see any reason to implement the `search` and `suggest` methods in `__call` instead of just exposing static methods ? Maybe I missed something ?

The problem of overloading the `__call` method from a trait is that other traits may overload it too, and it can't simply be solved by aliasing them because they all call `parent :: __ call`, the only solution would be to manually merge the code of all the `__call` into a single method, but that's weird.

For example, I encountered this problem while using the `Searchable` trait in combination with this one :
https://github.com/Laravel-Backpack/CRUD/blob/master/src/ModelTraits/SpatieTranslatable/HasTranslations.php