### PR TITLE
Console command to populate an index

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,7 @@ This will create a config file at `config/plastic.php` and a mapping directory a
 - [Aggregation](#aggregation)
 - [Suggestions](#suggestions)
 - [Mappings](#mappings)
+- [Populate An Index](#populate-an-index)
 - [Access The Client](#access-client)
 
 ## [Defining Searchable Models]()
@@ -316,6 +317,35 @@ You can always create a new Elasticsearch index and re-run the mappings. After r
 Its recommended to create your Elasticsearch index with an alias to ease the process of updating your model mappings with zero downtime. To learn more check out:
 
 <https://www.elastic.co/blog/changing-mapping-with-zero-downtime>
+
+## [Populate An Index]()
+
+Populating an index with searchable models can be done by running an Artisan console command :
+
+```bash
+php artisan plastic:populate [--mappings][--index=...][--database=...]
+```
+
+- `--mappings` Create the models mappings before populating the index
+- `--database=...` Database connection to use for mappings instead of the default one
+- `--index=...` Index to populate instead of the default one
+
+The list of models from which to recreate the documents has to be configured **per index** in `config/plastic.php`:
+```
+    'populate' => [
+        'models' => [
+            // Models for the default index
+            env('PLASTIC_INDEX', 'plastic') => [
+                App\Models\Article::class,
+                App\Models\Page::class,
+            ],
+            // Models for the index "another_index"
+            'another_index' => [
+                App\Models\User::class,
+            ],
+        ],
+    ],
+```
 
 ## [Access The Client]()
 

--- a/src/Console/Index/Populate.php
+++ b/src/Console/Index/Populate.php
@@ -68,6 +68,7 @@ class Populate extends Command
             $this->populateIndex($index);
         } catch (\Exception $e) {
             $this->warn('An error occured while populating the new index !');
+
             throw $e;
         }
     }

--- a/src/Console/Index/Populate.php
+++ b/src/Console/Index/Populate.php
@@ -51,6 +51,7 @@ class Populate extends Command
         $index = $this->index();
         if (!$this->existsStatement($index)) {
             $this->error('Index « '.$index.' » does not exists.');
+
             return;
         }
 
@@ -75,6 +76,7 @@ class Populate extends Command
      * Populates the index.
      *
      * @param string $index The index name
+     *
      * @throws \Exception
      */
     protected function populateIndex($index)
@@ -123,6 +125,7 @@ class Populate extends Command
      * Execute a exists statement for index.
      *
      * @param $index
+     *
      * @return bool
      */
     protected function existsStatement($index)
@@ -134,6 +137,7 @@ class Populate extends Command
      * Gets the models to index for the given index.
      *
      * @param $index
+     *
      * @return array
      */
     protected function models($index)
@@ -143,6 +147,7 @@ class Populate extends Command
 
     /**
      * Gets the chunk size.
+     *
      * @return int
      */
     protected function chunkSize()

--- a/src/Console/Index/Populate.php
+++ b/src/Console/Index/Populate.php
@@ -47,8 +47,9 @@ class Populate extends Command
      */
     public function handle()
     {
-        // Checks if the target index exists
         $index = $this->index();
+
+        // Checks if the target index exists
         if (!$this->existsStatement($index)) {
             $this->error('Index « '.$index.' » does not exists.');
 
@@ -58,6 +59,7 @@ class Populate extends Command
         // Runs the mappings
         if ($this->option('mappings')) {
             $this->call('mapping:rerun', [
+                '--index' => $index,
                 '--database' => $this->option('database'),
                 '--force'    => true,
             ]);

--- a/src/Console/Index/Populate.php
+++ b/src/Console/Index/Populate.php
@@ -59,7 +59,7 @@ class Populate extends Command
         // Runs the mappings
         if ($this->option('mappings')) {
             $this->call('mapping:rerun', [
-                '--index' => $index,
+                '--index'    => $index,
                 '--database' => $this->option('database'),
                 '--force'    => true,
             ]);

--- a/src/Console/Index/Populate.php
+++ b/src/Console/Index/Populate.php
@@ -27,19 +27,13 @@ class Populate extends Command
     protected $description = 'Populates an index';
 
     /**
-     * @var Client
+     * Gets the client.
+     *
+     * @return Client
      */
-    protected $client;
-
-    /**
-     * Reset constructor.
-     */
-    public function __construct()
+    public function client()
     {
-        parent::__construct();
-
-        // Gets the real index name (if aliased)
-        $this->client = Plastic::getClient();
+        return Plastic::getClient();
     }
 
     /**
@@ -133,7 +127,7 @@ class Populate extends Command
      */
     protected function existsStatement($index)
     {
-        return $this->client->indices()->exists(['index' => $index]);
+        return $this->client()->indices()->exists(['index' => $index]);
     }
 
     /**

--- a/src/Console/Index/Populate.php
+++ b/src/Console/Index/Populate.php
@@ -51,14 +51,14 @@ class Populate extends Command
         $index = $this->index();
         if (!$this->existsStatement($index)) {
             $this->error('Index « '.$index.' » does not exists.');
-            return ;
+            return;
         }
 
         // Runs the mappings
         if ($this->option('mappings')) {
             $this->call('mapping:rerun', [
                 '--database' => $this->option('database'),
-                '--force' => true,
+                '--force'    => true,
             ]);
         }
 
@@ -72,7 +72,7 @@ class Populate extends Command
     }
 
     /**
-     * Populates the index
+     * Populates the index.
      *
      * @param string $index The index name
      * @throws \Exception
@@ -110,7 +110,7 @@ class Populate extends Command
     }
 
     /**
-     * Gets the index to populate
+     * Gets the index to populate.
      *
      * @return array|string
      */
@@ -131,7 +131,7 @@ class Populate extends Command
     }
 
     /**
-     * Gets the models to index for the given index
+     * Gets the models to index for the given index.
      *
      * @param $index
      * @return array
@@ -142,7 +142,7 @@ class Populate extends Command
     }
 
     /**
-     * Gets the chunk size
+     * Gets the chunk size.
      * @return int
      */
     protected function chunkSize()

--- a/src/Console/Index/Populate.php
+++ b/src/Console/Index/Populate.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Sleimanx2\Plastic\Console\Index;
+
+use Elasticsearch\Client;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Sleimanx2\Plastic\Facades\Plastic;
+
+class Populate extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'plastic:populate 
+                            {--mappings : Create the models mappings before populating the index}
+                            {--database= : Database connection to use instead of the default one }
+                            {--index= : Index to populate instead of the default one}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Populates an index';
+
+    /**
+     * @var Client
+     */
+    protected $client;
+
+    /**
+     * Reset constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        // Gets the real index name (if aliased)
+        $this->client = Plastic::getClient();
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        // Checks if the target index exists
+        $index = $this->index();
+        if (!$this->existsStatement($index)) {
+            $this->error('Index « '.$index.' » does not exists.');
+            return ;
+        }
+
+        // Runs the mappings
+        if ($this->option('mappings')) {
+            $this->call('mapping:rerun', [
+                '--database' => $this->option('database'),
+                '--force' => true,
+            ]);
+        }
+
+        // Populates the index
+        try {
+            $this->populateIndex($index);
+        } catch (\Exception $e) {
+            $this->warn('An error occured while populating the new index !');
+            throw $e;
+        }
+    }
+
+    /**
+     * Populates the index
+     *
+     * @param string $index The index name
+     * @throws \Exception
+     */
+    protected function populateIndex($index)
+    {
+        $this->line('Populating the index « '.$index.' » ...');
+
+        // Replaces the current default index by the one we want to populate
+        $defaultIndex = Plastic::getDefaultIndex();
+        Plastic::setDefaultIndex($index);
+
+        // Disables query logging to prevent memory leak
+        $logging = DB::connection()->logging();
+        DB::connection()->disableQueryLog();
+
+        // Populates from models
+        $models = $this->models($index);
+        $chunkSize = $this->chunkSize();
+        foreach ($models as $model) {
+            $this->line('Indexing documents of model « '.$model.' » ...');
+            $model::chunk($chunkSize, function ($items) {
+                $this->line('Indexing chunk of '.$items->count().' documents ...');
+                Plastic::persist()->bulkSave($items);
+            });
+        }
+
+        // Restores query logging
+        if ($logging) {
+            DB::connection()->enableQueryLog();
+        }
+
+        // Restores the current default index
+        Plastic::setDefaultIndex($defaultIndex);
+    }
+
+    /**
+     * Gets the index to populate
+     *
+     * @return array|string
+     */
+    protected function index()
+    {
+        return $this->option('index') ?? Plastic::getDefaultIndex();
+    }
+
+    /**
+     * Execute a exists statement for index.
+     *
+     * @param $index
+     * @return bool
+     */
+    protected function existsStatement($index)
+    {
+        return $this->client->indices()->exists(['index' => $index]);
+    }
+
+    /**
+     * Gets the models to index for the given index
+     *
+     * @param $index
+     * @return array
+     */
+    protected function models($index)
+    {
+        return collect(config('plastic.populate.models'))->get($index, []);
+    }
+
+    /**
+     * Gets the chunk size
+     * @return int
+     */
+    protected function chunkSize()
+    {
+        return (int) config('plastic.populate.chunk_size');
+    }
+}

--- a/src/Console/Mapping/ReRun.php
+++ b/src/Console/Mapping/ReRun.php
@@ -14,7 +14,7 @@ class ReRun extends Command
      *
      * @var string
      */
-    protected $signature = 'mapping:rerun {--database=} {--force}';
+    protected $signature = 'mapping:rerun {--index=} {--database=} {--force}';
 
     /**
      * The console command description.
@@ -46,6 +46,7 @@ class ReRun extends Command
         ]);
 
         $this->call('mapping:run', [
+            '--index' => $this->option('index'),
             '--database' => $this->option('database'),
             '--force'    => true,
         ]);

--- a/src/Console/Mapping/ReRun.php
+++ b/src/Console/Mapping/ReRun.php
@@ -46,7 +46,7 @@ class ReRun extends Command
         ]);
 
         $this->call('mapping:run', [
-            '--index' => $this->option('index'),
+            '--index'    => $this->option('index'),
             '--database' => $this->option('database'),
             '--force'    => true,
         ]);

--- a/src/Console/Mapping/Run.php
+++ b/src/Console/Mapping/Run.php
@@ -54,7 +54,7 @@ class Run extends BaseCommand
         $path = $this->getMappingPath();
 
         $this->mapper->run($path, [
-            'step' => $this->option('step'),
+            'step'  => $this->option('step'),
             'index' => $this->option('index'),
         ]);
 

--- a/src/Console/Mapping/Run.php
+++ b/src/Console/Mapping/Run.php
@@ -14,7 +14,7 @@ class Run extends BaseCommand
      *
      * @var string
      */
-    protected $signature = 'mapping:run {--database=} {--step} {--force}';
+    protected $signature = 'mapping:run {--index=} {--database=} {--step} {--force}';
 
     /**
      * The console command description.
@@ -55,6 +55,7 @@ class Run extends BaseCommand
 
         $this->mapper->run($path, [
             'step' => $this->option('step'),
+            'index' => $this->option('index'),
         ]);
 
         // Once the mapper has run we will grab the note output and send it out to

--- a/src/IndexServiceProvider.php
+++ b/src/IndexServiceProvider.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Sleimanx2\Plastic;
+
+use Illuminate\Support\ServiceProvider;
+use Sleimanx2\Plastic\Console\Index\Populate;
+
+/**
+ * @codeCoverageIgnore
+ */
+class IndexServiceProvider extends ServiceProvider
+{
+    /**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
+    protected $defer = false;
+
+    /**
+     * Register the service provider.
+     */
+    public function register()
+    {
+        $this->registerCommands();
+    }
+
+    /**
+     * Register all needed commands.
+     */
+    protected function registerCommands()
+    {
+        $commands = ['Populate'];
+
+        foreach ($commands as $command) {
+            $this->{'register'.$command.'Command'}();
+        }
+
+        $this->commands([
+            'command.index.populate',
+        ]);
+    }
+
+    /**
+     * Register the Install command.
+     */
+    protected function registerPopulateCommand()
+    {
+        $this->app->singleton('command.index.populate', function () {
+            return new Populate();
+        });
+    }
+}

--- a/src/Mappings/Mapper.php
+++ b/src/Mappings/Mapper.php
@@ -85,7 +85,7 @@ class Mapper
      *
      * @param $file
      * @param $batch
-     * @param null|string $index The index on which to run the mappings instead of the default one
+     * @param string|null $index The index on which to run the mappings instead of the default one.
      */
     public function runMap($file, $batch, $index = null)
     {
@@ -105,7 +105,7 @@ class Mapper
      *
      * @param $file
      *
-     * @return mixed
+     * @return Mapping
      */
     public function resolve($file)
     {

--- a/src/Mappings/Mapper.php
+++ b/src/Mappings/Mapper.php
@@ -69,9 +69,10 @@ class Mapper
         $batch = $this->repository->getNextBatchNumber();
 
         $step = Arr::get($options, 'step', false);
+        $index = Arr::get($options, 'index');
 
         foreach ($mappings as $file) {
-            $this->runMap($file, $batch);
+            $this->runMap($file, $batch, $index);
 
             if ($step) {
                 $batch++;
@@ -84,10 +85,13 @@ class Mapper
      *
      * @param $file
      * @param $batch
+     * @param null|string $index The index on which to run the mappings instead of the default one
      */
-    public function runMap($file, $batch)
+    public function runMap($file, $batch, $index = null)
     {
         $mapping = $this->resolve($file);
+
+        $mapping->setIndex($index);
 
         $mapping->map();
 

--- a/src/Mappings/Mapping.php
+++ b/src/Mappings/Mapping.php
@@ -17,11 +17,38 @@ abstract class Mapping
     protected $model;
 
     /**
+     * Index name.
+     *
+     * @var
+     */
+    protected $index;
+
+    /**
      * Mapping constructor.
      */
     public function __construct()
     {
         $this->prepareModel();
+    }
+
+    /**
+     * Gets the index name.
+     *
+     * @return mixed
+     */
+    public function index()
+    {
+        return $this->index;
+    }
+
+    /**
+     * Sets the index name.
+     *
+     * @param $index
+     */
+    public function setIndex($index)
+    {
+        $this->index = $index;
     }
 
     /**
@@ -53,12 +80,12 @@ abstract class Mapping
     }
 
     /**
-     * Get the model elastic type.
+     * Get the model elastic index.
      *
      * @return mixed
      */
     public function getModelIndex()
     {
-        return $this->model->getDocumentIndex();
+        return $this->index() ?: $this->model->getDocumentIndex();
     }
 }

--- a/src/Mappings/Mapping.php
+++ b/src/Mappings/Mapping.php
@@ -19,7 +19,7 @@ abstract class Mapping
     /**
      * Index name.
      *
-     * @var
+     * @var string|null
      */
     protected $index;
 
@@ -34,7 +34,7 @@ abstract class Mapping
     /**
      * Gets the index name.
      *
-     * @return mixed
+     * @return string|null
      */
     public function index()
     {
@@ -44,7 +44,7 @@ abstract class Mapping
     /**
      * Sets the index name.
      *
-     * @param $index
+     * @param string|null $index
      */
     public function setIndex($index)
     {

--- a/src/PlasticServiceProvider.php
+++ b/src/PlasticServiceProvider.php
@@ -38,7 +38,7 @@ class PlasticServiceProvider extends ServiceProvider
     {
         $this->registerManager();
 
-        $this->registerMappings();
+        $this->registerProviders();
 
         $this->registerAlias();
     }
@@ -58,10 +58,14 @@ class PlasticServiceProvider extends ServiceProvider
     }
 
     /**
-     * Register the mappings service provider.
+     * Register the service providers.
      */
-    protected function registerMappings()
+    protected function registerProviders()
     {
+        // Register the index service provider.
+        $this->app->register(IndexServiceProvider::class);
+
+        // Register the mappings service provider.
         $this->app->register(MappingServiceProvider::class);
     }
 

--- a/src/Resources/config.php
+++ b/src/Resources/config.php
@@ -69,4 +69,39 @@ return [
     */
     'mappings'       => env('PLASTIC_MAPPINGS', 'mappings'),
 
+    /*
+    |------------------------------------------------------------------
+    | Populate settings
+    |------------------------------------------------------------------
+    |
+    | The settings for populating an index.
+    |
+    */
+    'populate' => [
+
+        /*
+        |------------------------------------------------------------------
+        | Models
+        |------------------------------------------------------------------
+        |
+        | The list of models, per index, from which to recreate the documents when running the console command to populate an index.
+        |
+        */
+        'models' => [
+
+            // The models for the default index
+            env('PLASTIC_INDEX', 'plastic') => [],
+        ],
+
+        /*
+        |------------------------------------------------------------------
+        | Chunk size
+        |------------------------------------------------------------------
+        |
+        | The size of documents chunks to index per model
+        |
+        */
+        'chunk_size' => 1000,
+    ],
+
 ];

--- a/tests/Console/MappingRunCommandTest.php
+++ b/tests/Console/MappingRunCommandTest.php
@@ -18,7 +18,7 @@ class MappingRunCommandTest extends \PHPUnit_Framework_TestCase
         $command->setLaravel($app);
 
         $mapper->shouldReceive('setConnection')->once()->with(null);
-        $mapper->shouldReceive('run')->once()->with(__DIR__.DIRECTORY_SEPARATOR.'mappings', ['step' => false]);
+        $mapper->shouldReceive('run')->once()->with(__DIR__.DIRECTORY_SEPARATOR.'mappings', ['step' => false, 'index' => null]);
         $mapper->shouldReceive('getNotes')->andReturn([]);
         $mapper->shouldReceive('repositoryExists')->once()->andReturn(true);
         $this->runCommand($command);
@@ -40,7 +40,7 @@ class MappingRunCommandTest extends \PHPUnit_Framework_TestCase
         $command->setLaravel($app);
 
         $mapper->shouldReceive('setConnection')->once()->with(null);
-        $mapper->shouldReceive('run')->once()->with(__DIR__.DIRECTORY_SEPARATOR.'mappings', ['step' => true]);
+        $mapper->shouldReceive('run')->once()->with(__DIR__.DIRECTORY_SEPARATOR.'mappings', ['step' => true, 'index' => null]);
         $mapper->shouldReceive('getNotes')->andReturn([]);
         $mapper->shouldReceive('repositoryExists')->once()->andReturn(true);
         $this->runCommand($command, ['--step' => true]);
@@ -62,7 +62,7 @@ class MappingRunCommandTest extends \PHPUnit_Framework_TestCase
         $command->setLaravel($app);
 
         $mapper->shouldReceive('setConnection')->once()->with('foo');
-        $mapper->shouldReceive('run')->once()->with(__DIR__.DIRECTORY_SEPARATOR.'mappings', ['step' => false]);
+        $mapper->shouldReceive('run')->once()->with(__DIR__.DIRECTORY_SEPARATOR.'mappings', ['step' => false, 'index' => null]);
         $mapper->shouldReceive('getNotes')->andReturn([]);
         $mapper->shouldReceive('repositoryExists')->once()->andReturn(true);
         $this->runCommand($command, ['--database' => 'foo']);

--- a/tests/Mappings/MappingMapperTest.php
+++ b/tests/Mappings/MappingMapperTest.php
@@ -31,8 +31,10 @@ class MappingMapperTest extends \PHPUnit_Framework_TestCase
         $mapper->getRepository()->shouldReceive('log')->once()->with('3_baz', 1);
 
         $barMock = Mockery::mock('stdClass');
+        $barMock->shouldReceive('setIndex')->once();
         $barMock->shouldReceive('map')->once();
         $bazMock = Mockery::mock('stdClass');
+        $bazMock->shouldReceive('setIndex')->once();
         $bazMock->shouldReceive('map')->once();
 
         $mapper->expects($this->at(0))->method('resolve')->with($this->equalTo('2_bar'))->will($this->returnValue($barMock));


### PR DESCRIPTION
Hello,

As proposed in #115 here is the command that populates an existing index.

----

### Usage

```
php artisan plastic:populate [--mappings][--index=...][--database=...]
```

- `--mappings` Create the models mappings before populating the index
- `--database=...` Database connection to use for mappings instead of the default one
- `--index=...` Index to populate instead of the default one

I added the `database` option only so that it can be forwarded to the mapping command, but I don't use it for the models as each of them may use its own database connection.

----
### Configuration

The list of models from which to recreate the documents has to be configured per index in `config/plastic.php`:
```
    'populate' => [
        'models' => [
            env('PLASTIC_INDEX', 'plastic') => [
                App\Models\Article::class,
                App\Models\Page::class,
            ],
            'another_index' => [
                App\Models\User::class,
            ],
        ],
    ],
```

----

I tested the command on Laravel 5.4 and ElasticSearch 5.2.2 by indexing 70k documents (size ~20MB)

I spent quite a bit of time trying to add some automated tests but I didn't succeed as I use facades and config, without a package like [orchestral/testbench](https://github.com/orchestral/testbench) this seems very hard to achieve. The only thing I can test for now is the existence of the command, would that be enough ?