### PR TITLE
Add static methods to support searching from model

### DIFF
--- a/src/Map/Blueprint.php
+++ b/src/Map/Blueprint.php
@@ -66,7 +66,7 @@ class Blueprint
             'type'  => $this->type,
             'body'  => [
                 $this->type => [
-                    '_source'    => [
+                    '_source' => [
                         'enabled' => true,
                     ],
                     'properties' => $this->toDSL($grammar),

--- a/src/Resources/config.php
+++ b/src/Resources/config.php
@@ -15,7 +15,7 @@ return [
     /*
      * Connection settings
      */
-    'connection'     => [
+    'connection' => [
 
         /*
         |--------------------------------------------------------------------------
@@ -26,7 +26,7 @@ return [
         | If no hosts are specified, the client will attempt to connect to localhost:9200.
         |
         */
-        'hosts'   => [
+        'hosts' => [
             env('PLASTIC_HOST', '127.0.0.1:9200'),
         ],
 
@@ -67,6 +67,6 @@ return [
     | The sql table to store the mappings logs
     |
     */
-    'mappings'       => env('PLASTIC_MAPPINGS', 'mappings'),
+    'mappings' => env('PLASTIC_MAPPINGS', 'mappings'),
 
 ];

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -35,24 +35,17 @@ trait Searchable
     public $documentVersion = null;
 
     /**
-     * Highlight search result.
-     *
-     * @var null|array
-     */
-    public $highlight = null;
-
-    /**
      * Searchable boot model.
      */
     public static function bootSearchable()
     {
-        static::saved(function (self $model) {
+        static::saved(function ($model) {
             if ($model->shouldSyncDocument()) {
                 $model->document()->save();
             }
         });
 
-        static::deleted(function (self $model) {
+        static::deleted(function ($model) {
             if ($model->shouldSyncDocument()) {
                 $model->document()->delete();
             }
@@ -167,6 +160,26 @@ trait Searchable
     }
 
     /**
+     * Start an elastic dsl search query builder
+     *
+     * @return mixed
+     */
+    public static function search()
+    {
+        return Plastic::search()->model(new static);
+    }
+
+    /**
+     * Start an elastic dsl suggest query builder
+     * 
+     * @return mixed
+     */
+    public static function suggest()
+    {
+        return Plastic::suggest()->index((new static)->getDocumentIndex());
+    }
+
+    /**
      * Handle dynamic method calls into the model.
      *
      * @param string $method
@@ -177,12 +190,12 @@ trait Searchable
     public function __call($method, $parameters)
     {
         if ($method == 'search') {
-            //Start an elastic dsl search query builder
+            // Start an elastic dsl search query builder
             return Plastic::search()->model($this);
         }
 
         if ($method == 'suggest') {
-            //Start an elastic dsl suggest query builder
+            // Start an elastic dsl suggest query builder
             return Plastic::suggest()->index($this->getDocumentIndex());
         }
 

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -7,10 +7,6 @@ use Illuminate\Support\Collection;
 use Sleimanx2\Plastic\Facades\Plastic;
 use Sleimanx2\Plastic\Persistence\EloquentPersistence;
 
-/**
- * @method static \Sleimanx2\Plastic\DSL\SearchBuilder search()
- * @method static \Sleimanx2\Plastic\DSL\SuggestionBuilder suggest()
- */
 trait Searchable
 {
     /**
@@ -169,7 +165,7 @@ trait Searchable
     /**
      * Start an elastic dsl search query builder.
      *
-     * @return mixed
+     * @return \Sleimanx2\Plastic\DSL\SearchBuilder
      */
     public static function search()
     {
@@ -179,7 +175,7 @@ trait Searchable
     /**
      * Start an elastic dsl suggest query builder.
      *
-     * @return mixed
+     * @return \Sleimanx2\Plastic\DSL\SuggestionBuilder
      */
     public static function suggest()
     {

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -35,17 +35,24 @@ trait Searchable
     public $documentVersion = null;
 
     /**
+     * Highlight search result.
+     *
+     * @var null|array
+     */
+    public $highlight = null;
+
+    /**
      * Searchable boot model.
      */
     public static function bootSearchable()
     {
-        static::saved(function ($model) {
+        static::saved(function (self $model) {
             if ($model->shouldSyncDocument()) {
                 $model->document()->save();
             }
         });
 
-        static::deleted(function ($model) {
+        static::deleted(function (self $model) {
             if ($model->shouldSyncDocument()) {
                 $model->document()->delete();
             }
@@ -171,7 +178,7 @@ trait Searchable
 
     /**
      * Start an elastic dsl suggest query builder
-     * 
+     *
      * @return mixed
      */
     public static function suggest()

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -167,23 +167,23 @@ trait Searchable
     }
 
     /**
-     * Start an elastic dsl search query builder
+     * Start an elastic dsl search query builder.
      *
      * @return mixed
      */
     public static function search()
     {
-        return Plastic::search()->model(new static);
+        return Plastic::search()->model(new static());
     }
 
     /**
-     * Start an elastic dsl suggest query builder
+     * Start an elastic dsl suggest query builder.
      *
      * @return mixed
      */
     public static function suggest()
     {
-        return Plastic::suggest()->index((new static)->getDocumentIndex());
+        return Plastic::suggest()->index((new static())->getDocumentIndex());
     }
 
     /**

--- a/tests/PlasticPaginatorTest.php
+++ b/tests/PlasticPaginatorTest.php
@@ -3,10 +3,10 @@
 class PlasticPaginatorTest extends \PHPUnit_Framework_TestCase
 {
     protected $elasticResult = [
-        'took'         => 0.2,
-        'timed_out'    => false,
-        '_shards'      => 2,
-        'hits'         => [
+        'took'      => 0.2,
+        'timed_out' => false,
+        '_shards'   => 2,
+        'hits'      => [
             'total'     => 2,
             'max_score' => 3,
             'hits'      => ['foo', 'bar'],

--- a/tests/PlasticResultTest.php
+++ b/tests/PlasticResultTest.php
@@ -3,10 +3,10 @@
 class PlasticResultTest extends \PHPUnit_Framework_TestCase
 {
     protected $elasticResult = [
-        'took'         => 0.2,
-        'timed_out'    => false,
-        '_shards'      => 2,
-        'hits'         => [
+        'took'      => 0.2,
+        'timed_out' => false,
+        '_shards'   => 2,
+        'hits'      => [
             'total'     => 2,
             'max_score' => 3,
             'hits'      => ['foo', 'bar'],


### PR DESCRIPTION
In the documentation, it says you can do the following.

```
Book::search()...
```

On the latest Laravel version, __callStatic is called instead of __call on the model class directly. This causes it to call search() on the QueryBuilder of the ORM which doesn't exist and errors. 

This pull request is to fix this this error and allow for the specified functionality. I do realize that there is another PR similar #120. However, there has been no reply to that PR in awhile.