### PR TITLE
Workaround for a critical error from a bug in PHP 7

### DIFF
--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -46,13 +46,13 @@ trait Searchable
      */
     public static function bootSearchable()
     {
-        static::saved(function (self $model) {
+        static::saved(function ($model) {
             if ($model->shouldSyncDocument()) {
                 $model->document()->save();
             }
         });
 
-        static::deleted(function (self $model) {
+        static::deleted(function ($model) {
             if ($model->shouldSyncDocument()) {
                 $model->document()->delete();
             }


### PR DESCRIPTION
Hello,

I've encountered an error when saving multiple `Searchable` items from different models. It's related to type-hinting closures with the `self` keyword from a trait. While it's a bug in the PHP interpreter, it can cause critical errors in applications using the `Searchable trait`.

This PR is just a workaround for this error.

It's related to the bug declared here: https://bugs.php.net/bug.php?id=75079

And here is an example to reproduce it:

```php
trait T {
    public static function test()
    {
        return function (self $x) {
            print_r($x);
        };
    }
}

class A {
    use T;
}

class B {
    use T;
}

$a = A::test();
$b = B::test();

$a(new A());
$b(new B());
```

Result:
> B Object
> (
> )
> Fatal error:  Uncaught TypeError: Argument 1 passed to A::{closure}() must be an instance of B, instance of A given, called in [...][...] on line 24 and defined in...