### PR TITLE
Revert "Support text type"

### DIFF
--- a/docs/mapping.md
+++ b/docs/mapping.md
@@ -1,18 +1,18 @@
 ##List of available mappings
 
-`text`,`date`,`long`,`integer`,`short`,`byte`,`double`,`binary`,`float`,`boolean`,`point`,`shape`,`ip`,`completion`,`tokenCount`,`nested`
+`string`,`date`,`long`,`integer`,`short`,`byte`,`double`,`binary`,`float`,`boolean`,`point`,`shape`,`ip`,`completion`,`tokenCount`,`nested`
 
 All mappings use the same signature except for the nested mapping lets see some examples.
 
 ```php
-$map->text('title');
+$map->string('title');
 
 $map->point('location');
 
 $map->shape('area');
 
 $map->nested('tag',function(Blueprint $map){
-  $map->text('name');
+  $map->string('name');
 })
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -279,7 +279,7 @@ class AppTag extends Mapping
     public function map()
     {
         Map::create($this->getModelType(), function (Blueprint $map) {
-            $map->text('name')->store('true')->index('analyzed');
+            $map->string('name')->store('true')->index('analyzed');
 
             // instead of the fluent syntax we can use the second method argument to fill the attributes
             $map->completion('suggestion', ['analyzer' => 'simple', 'search_analyzer' => 'simple']);

--- a/src/Map/Blueprint.php
+++ b/src/Map/Blueprint.php
@@ -88,16 +88,16 @@ class Blueprint
     }
 
     /**
-     * Add a text field to the map.
+     * Add a string field to the map.
      *
      * @param string $field
      * @param array  $attributes
      *
      * @return Fluent
      */
-    public function text($field, $attributes = [])
+    public function string($field, $attributes = [])
     {
-        return $this->addField('text', $field, $attributes);
+        return $this->addField('string', $field, $attributes);
     }
 
     /**

--- a/src/Map/Grammar.php
+++ b/src/Map/Grammar.php
@@ -272,16 +272,16 @@ class Grammar
     }
 
     /**
-     * Compile a text map.
+     * Compile a string map.
      *
      * @param Fluent $fluent
      *
      * @return array
      */
-    public function compileText(Fluent $fluent)
+    public function compileString(Fluent $fluent)
     {
         $map = [
-            'type'                   => 'text',
+            'type'                   => 'string',
             'analyzer'               => $fluent->analyzer,
             'boost'                  => $fluent->boost,
             'doc_values'             => $fluent->doc_values,

--- a/tests/Map/MapGrammarTest.php
+++ b/tests/Map/MapGrammarTest.php
@@ -175,13 +175,13 @@ class MapGrammarTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_adds_a_text_map()
+    public function it_adds_a_string_map()
     {
         $blueprint = new Blueprint('post');
         $blueprint->create();
-        $blueprint->text('body', ['analyzer' => 'foo', 'boost' => true]);
+        $blueprint->string('body', ['analyzer' => 'foo', 'boost' => true]);
         $statement = $blueprint->toDSL($this->getGrammar());
-        $this->assertEquals(['body' => ['type' => 'text', 'analyzer' => 'foo', 'boost' => true]], $statement);
+        $this->assertEquals(['body' => ['type' => 'string', 'analyzer' => 'foo', 'boost' => true]], $statement);
     }
 
     /**
@@ -192,10 +192,10 @@ class MapGrammarTest extends \PHPUnit_Framework_TestCase
         $blueprint = new Blueprint('post');
         $blueprint->create();
         $blueprint->nested('tags', function ($blueprint) {
-            $blueprint->text('name');
+            $blueprint->string('name');
         });
         $statement = $blueprint->toDSL($this->getGrammar());
-        $this->assertEquals(['tags' => ['type' => 'nested', 'properties' => ['name' => ['type' => 'text']]]],
+        $this->assertEquals(['tags' => ['type' => 'nested', 'properties' => ['name' => ['type' => 'string']]]],
             $statement);
     }
 
@@ -207,10 +207,10 @@ class MapGrammarTest extends \PHPUnit_Framework_TestCase
         $blueprint = new Blueprint('post');
         $blueprint->create();
         $blueprint->object('tags', function ($blueprint) {
-            $blueprint->text('name');
+            $blueprint->string('name');
         });
         $statement = $blueprint->toDSL($this->getGrammar());
-        $this->assertEquals(['tags' => ['properties' => ['name' => ['type' => 'text']]]],
+        $this->assertEquals(['tags' => ['properties' => ['name' => ['type' => 'string']]]],
             $statement);
     }
 


### PR DESCRIPTION
Reverts sleimanx2/plastic#132

`keyword` also needs implementing as described here https://www.elastic.co/blog/strings-are-dead-long-live-strings