### PR TITLE
change elasticsearch type: string to text

### DIFF
--- a/docs/mapping.md
+++ b/docs/mapping.md
@@ -1,18 +1,18 @@
 ##List of available mappings
 
-`string`,`date`,`long`,`integer`,`short`,`byte`,`double`,`binary`,`float`,`boolean`,`point`,`shape`,`ip`,`completion`,`tokenCount`,`nested`
+`text`,`date`,`long`,`integer`,`short`,`byte`,`double`,`binary`,`float`,`boolean`,`point`,`shape`,`ip`,`completion`,`tokenCount`,`nested`
 
 All mappings use the same signature except for the nested mapping lets see some examples.
 
 ```php
-$map->string('title');
+$map->text('title');
 
 $map->point('location');
 
 $map->shape('area');
 
 $map->nested('tag',function(Blueprint $map){
-  $map->string('name');
+  $map->text('name');
 })
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -279,7 +279,7 @@ class AppTag extends Mapping
     public function map()
     {
         Map::create($this->getModelType(), function (Blueprint $map) {
-            $map->string('name')->store('true')->index('analyzed');
+            $map->text('name')->store('true')->index('analyzed');
 
             // instead of the fluent syntax we can use the second method argument to fill the attributes
             $map->completion('suggestion', ['analyzer' => 'simple', 'search_analyzer' => 'simple']);

--- a/src/Map/Blueprint.php
+++ b/src/Map/Blueprint.php
@@ -90,14 +90,14 @@ class Blueprint
     /**
      * Add a string field to the map.
      *
-     * @param string $field
+     * @param text $field
      * @param array  $attributes
      *
      * @return Fluent
      */
-    public function string($field, $attributes = [])
+    public function text($field, $attributes = [])
     {
-        return $this->addField('string', $field, $attributes);
+        return $this->addField('text', $field, $attributes);
     }
 
     /**

--- a/src/Map/Blueprint.php
+++ b/src/Map/Blueprint.php
@@ -101,6 +101,19 @@ class Blueprint
     }
 
     /**
+     * Add a string field to the map.
+     *
+     * @param text $field
+     * @param array  $attributes
+     *
+     * @return Fluent
+     */
+    public function keyword($field, $attributes = [])
+    {
+        return $this->addField('keyword', $field, $attributes);
+    }
+
+    /**
      * Add a date field to the map.
      *
      * @param string $field

--- a/src/Map/Grammar.php
+++ b/src/Map/Grammar.php
@@ -272,16 +272,16 @@ class Grammar
     }
 
     /**
-     * Compile a string map.
+     * Compile a text map.
      *
      * @param Fluent $fluent
      *
      * @return array
      */
-    public function compileString(Fluent $fluent)
+    public function compileText(Fluent $fluent)
     {
         $map = [
-            'type'                   => 'string',
+            'type'                   => 'text',
             'analyzer'               => $fluent->analyzer,
             'boost'                  => $fluent->boost,
             'doc_values'             => $fluent->doc_values,

--- a/src/Map/Grammar.php
+++ b/src/Map/Grammar.php
@@ -305,6 +305,36 @@ class Grammar
     }
 
     /**
+     * Compile a keyword map.
+     *
+     * https://www.elastic.co/guide/en/elasticsearch/reference/current/keyword.html
+     *
+     * @param Fluent $fluent
+     *
+     * @return array
+     */
+    public function compileKeyword(Fluent $fluent)
+    {
+        $map = [
+            'type'                   => 'keyword',
+            'boost'                  => $fluent->boost,
+            'doc_values'             => $fluent->doc_values,
+            'eager_global_ordinals'  => $fluent->eager_global_ordinals,
+            'fields'                 => $fluent->fields,
+            'ignore_above'           => $fluent->ignore_above,
+            'index'                  => $fluent->index,
+            'index_options'          => $fluent->index_options,
+            'norms'                  => $fluent->norms,
+            'null_value'             => $fluent->null_value,
+            'store'                  => $fluent->store,
+            'similarity'             => $fluent->similarity,
+            'normalizer'             => $fluent->normalizer,
+        ];
+
+        return $this->formatMap($map);
+    }
+
+    /**
      * Compile a numeric map.
      *
      * @param Fluent $fluent

--- a/tests/Map/MapGrammarTest.php
+++ b/tests/Map/MapGrammarTest.php
@@ -179,9 +179,9 @@ class MapGrammarTest extends \PHPUnit_Framework_TestCase
     {
         $blueprint = new Blueprint('post');
         $blueprint->create();
-        $blueprint->string('body', ['analyzer' => 'foo', 'boost' => true]);
+        $blueprint->text('body', ['analyzer' => 'foo', 'boost' => true]);
         $statement = $blueprint->toDSL($this->getGrammar());
-        $this->assertEquals(['body' => ['type' => 'string', 'analyzer' => 'foo', 'boost' => true]], $statement);
+        $this->assertEquals(['body' => ['type' => 'text', 'analyzer' => 'foo', 'boost' => true]], $statement);
     }
 
     /**
@@ -192,10 +192,10 @@ class MapGrammarTest extends \PHPUnit_Framework_TestCase
         $blueprint = new Blueprint('post');
         $blueprint->create();
         $blueprint->nested('tags', function ($blueprint) {
-            $blueprint->string('name');
+            $blueprint->text('name');
         });
         $statement = $blueprint->toDSL($this->getGrammar());
-        $this->assertEquals(['tags' => ['type' => 'nested', 'properties' => ['name' => ['type' => 'string']]]],
+        $this->assertEquals(['tags' => ['type' => 'nested', 'properties' => ['name' => ['type' => 'text']]]],
             $statement);
     }
 
@@ -207,10 +207,10 @@ class MapGrammarTest extends \PHPUnit_Framework_TestCase
         $blueprint = new Blueprint('post');
         $blueprint->create();
         $blueprint->object('tags', function ($blueprint) {
-            $blueprint->string('name');
+            $blueprint->text('name');
         });
         $statement = $blueprint->toDSL($this->getGrammar());
-        $this->assertEquals(['tags' => ['properties' => ['name' => ['type' => 'string']]]],
+        $this->assertEquals(['tags' => ['properties' => ['name' => ['type' => 'text']]]],
             $statement);
     }
 


### PR DESCRIPTION
change elasticsearch type: string to text

https://www.elastic.co/blog/strings-are-dead-long-live-strings

Before:
```
{
  "foo": {
    "type" "string",
    "index": "analyzed"
  }
}
```
Now need to be mapped as a text field:
```
{
  "foo": {
    "type" "text",
    "index": true
  }
}
```