### PR TITLE
Set current page

### DIFF
--- a/src/DSL/SearchBuilder.php
+++ b/src/DSL/SearchBuilder.php
@@ -843,6 +843,6 @@ class SearchBuilder
      */
     protected function getCurrentPage()
     {
-        return \Request::get('page') ? (int) \Request::get('page') : 1;
+        return (int) \Request::get('page', 1);
     }
 }

--- a/src/DSL/SearchBuilder.php
+++ b/src/DSL/SearchBuilder.php
@@ -796,8 +796,7 @@ class SearchBuilder
     /**
      * Paginate result hits.
      *
-     * @param int $limit
-     *
+     * @param int      $limit
      * @param null|int $current
      *
      * @return PlasticPaginator

--- a/src/DSL/SearchBuilder.php
+++ b/src/DSL/SearchBuilder.php
@@ -798,11 +798,13 @@ class SearchBuilder
      *
      * @param int $limit
      *
+     * @param null|int $current
+     *
      * @return PlasticPaginator
      */
-    public function paginate($limit = 25)
+    public function paginate($limit = 25, $current = null)
     {
-        $page = $this->getCurrentPage();
+        $page = $this->getCurrentPage($current);
 
         $from = $limit * ($page - 1);
         $size = $limit;
@@ -839,10 +841,12 @@ class SearchBuilder
     /**
      * return the current query string value.
      *
+     * @param null|int $current
+     *
      * @return int
      */
-    protected function getCurrentPage()
+    protected function getCurrentPage($current)
     {
-        return (int) \Request::get('page', 1);
+        return $current ?: (int) \Request::get('page', 1);
     }
 }

--- a/tests/DSL/SearchBuilderTest.php
+++ b/tests/DSL/SearchBuilderTest.php
@@ -526,6 +526,30 @@ class SearchBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf(\Sleimanx2\Plastic\PlasticPaginator::class, $builder->paginate());
     }
 
+    /** @test */
+    public function it_paginates_set_current_page_query_result()
+    {
+        $builder = $this->getBuilder();
+
+        $result = new PlasticResult([
+            'took'      => '200',
+            'timed_out' => false,
+            '_shards'   => 2,
+            'hits'      => [
+                'hits'      => [],
+                'total'     => 0,
+                'max_score' => 0,
+            ],
+        ]);
+        $builder->shouldAllowMockingProtectedMethods();
+        $builder->shouldReceive('getCurrentPage')->once()->with(2)->andReturn(2);
+        $builder->shouldReceive('from')->once()->with(25)->andReturn($builder);
+        $builder->shouldReceive('size')->once()->with(25)->andReturn($builder);
+        $builder->shouldReceive('get')->once()->andReturn($result);
+
+        $this->assertInstanceOf(\Sleimanx2\Plastic\PlasticPaginator::class, $builder->paginate(25, 2));
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
It provides another to set current page for pagination.

Usage:
```php
$current = 2;
$limit = 25;

return User::search()->paginate($limit, $current);
```