### PR TITLE
Autopackage discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,5 +39,12 @@
   },
   "config": {
     "preferred-install": "dist"
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Sleimanx2\\Plastic\\PlasticServiceProvider"
+      ]
+    }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@
 composer require sleimanx2/plastic
 ```
 
-Then we need to add the plastic service provider to `config/app.php` under the providers key:
+If you are using **Laravel >=5.5** the service provider will be **automatically discovered** otherwise we need to add the plastic service provider to `config/app.php` under the providers key:
 
 ```php
 Sleimanx2\Plastic\PlasticServiceProvider::class


### PR DESCRIPTION
Let Laravel >= 5.5 discover the package automatically so we don't have to register it manually 