### PR TITLE
Make `setModelFiller` fluent

### DIFF
--- a/src/DSL/SearchBuilder.php
+++ b/src/DSL/SearchBuilder.php
@@ -730,6 +730,8 @@ class SearchBuilder
     public function setModelFiller(FillerInterface $filler)
     {
         $this->modelFiller = $filler;
+        
+        return $this;
     }
 
     /**


### PR DESCRIPTION
There is currently no config option to set the model filler. Also trying to set it via `Model::search()->setModelFiller()` because each call to `search` starts a new builder instance.